### PR TITLE
Fix post-login routing for players

### DIFF
--- a/src/components/AppRouter.tsx
+++ b/src/components/AppRouter.tsx
@@ -120,10 +120,17 @@ export function AppRouter() {
             <h1 className="text-4xl font-bold text-gray-900 mb-2">🎯 Trivia Party</h1>
             <p className="text-gray-600">Multi-user trivia game for in-person play</p>
           </div>
-          <AuthForms onSuccess={() => {
-            // Will be handled by auth state change
-            setCurrentView('host-menu') // Default to host menu, will update when auth state changes
-          }} />
+          <AuthForms
+            onSuccess={() => {
+              // Allow auth state change effect to route based on role while preserving deep links
+              setCurrentView((previous) => {
+                if (previous === 'player-join' || previous === 'tv-display' || previous === 'host-dashboard' || previous === 'leaderboard') {
+                  return previous
+                }
+                return 'auth'
+              })
+            }}
+          />
         </div>
       </div>
     )


### PR DESCRIPTION
## Summary
- adjust the post-authentication callback so we rely on the auth state effect to route users to the appropriate view
- preserve deep-linked views for players and hosts instead of forcing everyone to the host menu after signing in

## Testing
- `npm run lint` *(fails: ESLint 9 requires eslint.config.js and repo still uses legacy config)*

------
https://chatgpt.com/codex/tasks/task_e_68d3da9b2fb483239d9e452c721668f2