### PR TITLE
Reapply join access policies for setup games

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
   env: { browser: true, es2020: true },
   extends: [
     'eslint:recommended',
-    '@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],

--- a/database/migrations/009_update_join_access_policies.sql
+++ b/database/migrations/009_update_join_access_policies.sql
@@ -1,0 +1,61 @@
+-- Migration: Expand join access policies to cover setup games and allow authenticated players to lobby
+-- access before they are formally part of a game.
+
+-- Allow anonymous viewers (including unauthenticated join links) to see games that are
+-- still setting up so the landing page can load context before the game starts.
+ALTER POLICY "anonymous_read_games" ON games
+  USING (status IN ('setup', 'active', 'completed'));
+
+-- Allow authenticated players (e.g., users who signed in before joining) to load the
+-- basic game details needed to join via a shared link without being members yet.
+CREATE POLICY "authenticated_read_joinable_games" ON games
+  FOR SELECT TO authenticated
+  USING (status IN ('setup', 'active', 'completed'));
+
+-- Allow anonymous access to team listings for games that are setting up so join pages
+-- can render available teams.
+ALTER POLICY "anonymous_read_teams" ON teams
+  USING (
+    game_id IN (
+      SELECT id FROM games WHERE status IN ('setup', 'active', 'completed')
+    )
+  );
+
+-- Allow authenticated players to inspect teams for joinable games even before they
+-- have a player row created.
+CREATE POLICY "authenticated_read_joinable_teams" ON teams
+  FOR SELECT TO authenticated
+  USING (
+    game_id IN (
+      SELECT id FROM games WHERE status IN ('setup', 'active', 'completed')
+    )
+  );
+
+-- Allow anonymous viewers to see lobby participants for context while a game is being
+-- set up.
+ALTER POLICY "anonymous_read_players" ON players
+  USING (
+    game_id IN (
+      SELECT id FROM games WHERE status IN ('setup', 'active', 'completed')
+    )
+  );
+
+-- Allow authenticated players to see lobby participants while deciding to join.
+CREATE POLICY "authenticated_read_joinable_players" ON players
+  FOR SELECT TO authenticated
+  USING (
+    game_id IN (
+      SELECT id FROM games WHERE status IN ('setup', 'active', 'completed')
+    )
+  );
+
+-- Allow authenticated users to spin up a new team in a lobby before they have a player
+-- row (they will immediately create one after) while limiting creation to games that
+-- are still joinable.
+CREATE POLICY "players_create_joinable_teams" ON teams
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    game_id IN (
+      SELECT id FROM games WHERE status IN ('setup', 'active')
+    )
+  );

--- a/database/migrations/010_reapply_join_policies.sql
+++ b/database/migrations/010_reapply_join_policies.sql
@@ -1,0 +1,72 @@
+-- Migration: Reapply and expand join access policies for setup games
+-- This migration drops the previous join-related policies and recreates them
+-- with consistent predicates so both anonymous viewers and authenticated players
+-- can discover games, teams, and lobby participants while a game is being set up.
+
+-- Games ---------------------------------------------------------------
+DROP POLICY IF EXISTS "anonymous_read_games" ON games;
+CREATE POLICY "anonymous_read_games" ON games
+  FOR SELECT TO anon
+  USING (status IN ('setup', 'active', 'paused', 'completed'));
+
+DROP POLICY IF EXISTS "authenticated_read_joinable_games" ON games;
+CREATE POLICY "authenticated_read_joinable_games" ON games
+  FOR SELECT TO authenticated
+  USING (status IN ('setup', 'active', 'paused', 'completed'));
+
+-- Teams ---------------------------------------------------------------
+DROP POLICY IF EXISTS "anonymous_read_teams" ON teams;
+CREATE POLICY "anonymous_read_teams" ON teams
+  FOR SELECT TO anon
+  USING (
+    game_id IN (
+      SELECT id
+      FROM games
+      WHERE status IN ('setup', 'active', 'paused', 'completed')
+    )
+  );
+
+DROP POLICY IF EXISTS "authenticated_read_joinable_teams" ON teams;
+CREATE POLICY "authenticated_read_joinable_teams" ON teams
+  FOR SELECT TO authenticated
+  USING (
+    game_id IN (
+      SELECT id
+      FROM games
+      WHERE status IN ('setup', 'active', 'paused', 'completed')
+    )
+  );
+
+DROP POLICY IF EXISTS "players_create_joinable_teams" ON teams;
+CREATE POLICY "players_create_joinable_teams" ON teams
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    game_id IN (
+      SELECT id
+      FROM games
+      WHERE status IN ('setup', 'active')
+    )
+  );
+
+-- Players -------------------------------------------------------------
+DROP POLICY IF EXISTS "anonymous_read_players" ON players;
+CREATE POLICY "anonymous_read_players" ON players
+  FOR SELECT TO anon
+  USING (
+    game_id IN (
+      SELECT id
+      FROM games
+      WHERE status IN ('setup', 'active', 'paused', 'completed')
+    )
+  );
+
+DROP POLICY IF EXISTS "authenticated_read_joinable_players" ON players;
+CREATE POLICY "authenticated_read_joinable_players" ON players
+  FOR SELECT TO authenticated
+  USING (
+    game_id IN (
+      SELECT id
+      FROM games
+      WHERE status IN ('setup', 'active', 'paused', 'completed')
+    )
+  );

--- a/src/components/HostDashboard.tsx
+++ b/src/components/HostDashboard.tsx
@@ -18,7 +18,9 @@ import {
   CheckCircle,
   Settings,
   Monitor,
-  RefreshCw
+  RefreshCw,
+  Copy,
+  Check
 } from 'lucide-react'
 import { GameService } from '../services/gameService'
 import { TeamService } from '../services/teamService'
@@ -43,6 +45,9 @@ export const HostDashboard: React.FC<HostDashboardProps> = ({ gameId, onShowTVDi
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [actionLoading, setActionLoading] = useState<string | null>(null)
+  const [copiedJoinLink, setCopiedJoinLink] = useState(false)
+
+  const joinLink = `${window.location.origin}/join/${gameId}`
 
   useEffect(() => {
     loadGameData()
@@ -224,6 +229,21 @@ export const HostDashboard: React.FC<HostDashboardProps> = ({ gameId, onShowTVDi
     }
   }
 
+  const handleCopyJoinLink = async () => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(joinLink)
+        setCopiedJoinLink(true)
+        setTimeout(() => setCopiedJoinLink(false), 2000)
+      } else {
+        window.prompt('Copy this link to share with players:', joinLink)
+      }
+    } catch (error) {
+      console.error('Failed to copy join link:', error)
+      window.prompt('Copy this link to share with players:', joinLink)
+    }
+  }
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
@@ -271,9 +291,34 @@ export const HostDashboard: React.FC<HostDashboardProps> = ({ gameId, onShowTVDi
         </div>
         <Button onClick={onShowTVDisplay} className="gap-2">
           <Monitor className="h-4 w-4" />
-          TV Display
+          Open TV Display
         </Button>
       </div>
+
+      {/* Invite Players */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Invite Players</CardTitle>
+          <CardDescription>
+            Share this link or open the TV display to show the QR code in a separate window.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <code className="block bg-muted px-3 py-2 rounded text-sm break-all border border-muted-foreground/10">
+            {joinLink}
+          </code>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="secondary" onClick={handleCopyJoinLink} className="gap-2">
+              {copiedJoinLink ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+              {copiedJoinLink ? 'Copied!' : 'Copy Join Link'}
+            </Button>
+            <Button variant="outline" onClick={onShowTVDisplay} className="gap-2">
+              <Monitor className="h-4 w-4" />
+              Launch TV Display
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Progress Bar */}
       <div className="space-y-2">


### PR DESCRIPTION
## Summary
- drop and recreate the anonymous and authenticated join policies on games, teams, and players
- allow join pages to read setup, active, paused, and completed games and their lobby rosters
- keep team creation constrained to joinable games while ensuring policies exist after migrations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3dd44ef1483239f8631ac0ed9fd90