### PR TITLE
Fix recursive games policy

### DIFF
--- a/database/migrations/011_fix_recursive_game_policy.sql
+++ b/database/migrations/011_fix_recursive_game_policy.sql
@@ -1,0 +1,21 @@
+-- Migration: Break recursive policy dependency between games and players
+-- The previous policy "players_read_joined_games" referenced the players table
+-- while some player policies reference games. This created a cyclical dependency
+-- that PostgreSQL detected as infinite recursion when evaluating row level
+-- security, preventing games from being queried. We remove that policy and rely
+-- on the joinable status based policies for exposing games to authenticated
+-- players.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'games'
+      AND policyname = 'players_read_joined_games'
+  ) THEN
+    EXECUTE 'DROP POLICY "players_read_joined_games" ON games;';
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary
- drop the games policy that required membership checks through the players table
- explain the recursion issue and rely on the existing joinable-status policies for access control

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3e7813cac8323b75c20a093d5e89a