### PR TITLE
Remove duplicate getGameQuestion method

### DIFF
--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -211,46 +211,6 @@ export class QuestionService {
   // Get game question with randomized answers
   static async getGameQuestion(gameId: string, roundNumber: number, questionNumber: number): Promise<ApiResponse<QuestionWithAnswers>> {
     try {
-      const { data: existing, error: fetchError } = await supabase
-        .from('game_questions')
-        .select('id')
-        .eq('game_id', gameId)
-
-      if (fetchError) {
-        return {
-          data: null,
-          error: { message: fetchError.message, code: 'DATABASE_ERROR', details: fetchError }
-        }
-      }
-
-      if (!existing || existing.length === 0) {
-        return { data: true, error: null }
-      }
-
-      const { error: deleteError } = await supabase
-        .from('game_questions')
-        .delete()
-        .eq('game_id', gameId)
-
-      if (deleteError) {
-        return {
-          data: null,
-          error: { message: deleteError.message, code: 'DATABASE_ERROR', details: deleteError }
-        }
-      }
-
-      return { data: true, error: null }
-    } catch (error) {
-      return {
-        data: null,
-        error: { message: 'Failed to clear existing game questions', code: 'UNKNOWN_ERROR', details: error }
-      }
-    }
-  }
-
-  // Get game question with randomized answers
-  static async getGameQuestion(gameId: string, roundNumber: number, questionNumber: number): Promise<ApiResponse<QuestionWithAnswers>> {
-    try {
       const fetchQuestion = (positionField: 'question_order' | 'question_number') => (
         supabase
           .from('game_questions')


### PR DESCRIPTION
## Summary
- remove the duplicate getGameQuestion definition that returned the wrong shape
- rely on the existing implementation that fetches and normalizes game questions

## Testing
- `npm run build` *(fails: existing TypeScript errors in test and service files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f85ff43c8323aae65ab1b5618a52