### PR TITLE
Add RPC-backed question preparation flow

### DIFF
--- a/database/migrations/012_create_prepare_game_question_function.sql
+++ b/database/migrations/012_create_prepare_game_question_function.sql
@@ -1,0 +1,89 @@
+-- Migration: Create helper function to safely prepare game questions
+
+CREATE OR REPLACE FUNCTION prepare_game_question(
+  p_game_id UUID,
+  p_question_id UUID,
+  p_round_number INTEGER,
+  p_question_number INTEGER,
+  p_shuffled_answers TEXT[],
+  p_correct_position INTEGER,
+  p_time_limit INTEGER DEFAULT NULL
+)
+RETURNS game_questions AS
+$$
+DECLARE
+  current_user_id UUID := auth.uid();
+  position_column TEXT;
+  has_time_limit BOOLEAN;
+  inserted_record game_questions%ROWTYPE;
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required' USING HINT = 'AUTH_REQUIRED';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM games
+    WHERE id = p_game_id
+      AND host_id = current_user_id
+  ) THEN
+    RAISE EXCEPTION 'Not authorized to manage this game' USING HINT = 'NOT_GAME_HOST';
+  END IF;
+
+  SELECT column_name
+  INTO position_column
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'game_questions'
+    AND column_name IN ('question_order', 'question_number')
+  ORDER BY CASE column_name WHEN 'question_order' THEN 1 ELSE 2 END
+  LIMIT 1;
+
+  IF position_column IS NULL THEN
+    position_column := 'question_order';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'game_questions'
+      AND column_name = 'time_limit'
+  ) INTO has_time_limit;
+
+  EXECUTE format(
+    'DELETE FROM game_questions WHERE game_id = $1 AND round_number = $2 AND %I = $3',
+    position_column
+  )
+  USING p_game_id, p_round_number, p_question_number;
+
+  DELETE FROM game_questions
+  WHERE game_id = p_game_id
+    AND question_id = p_question_id;
+
+  IF has_time_limit THEN
+    EXECUTE format(
+      'INSERT INTO game_questions (game_id, question_id, round_number, %I, shuffled_answers, correct_position, time_limit)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *',
+      position_column
+    )
+    INTO inserted_record
+    USING p_game_id, p_question_id, p_round_number, p_question_number, p_shuffled_answers, p_correct_position, p_time_limit;
+  ELSE
+    EXECUTE format(
+      'INSERT INTO game_questions (game_id, question_id, round_number, %I, shuffled_answers, correct_position)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING *',
+      position_column
+    )
+    INTO inserted_record
+    USING p_game_id, p_question_id, p_round_number, p_question_number, p_shuffled_answers, p_correct_position;
+  END IF;
+
+  RETURN inserted_record;
+END;
+$$
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public;

--- a/src/services/__tests__/questionService.addQuestionToGame.test.ts
+++ b/src/services/__tests__/questionService.addQuestionToGame.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, beforeEach, afterEach, vi, type Mock } from 'vitest'
+import { QuestionService } from '../questionService'
+import type { Question, RandomizedQuestion } from '../../types/question'
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    rpc: vi.fn(),
+    from: vi.fn()
+  }
+}))
+
+const { supabase } = await import('../../lib/supabase')
+
+describe('QuestionService.addQuestionToGame', () => {
+  const baseQuestion: Question = {
+    id: 'question-id',
+    category: 'General',
+    subcategory: null,
+    difficulty: 'medium',
+    question: 'What is the answer?',
+    a: 'Answer A',
+    b: 'Answer B',
+    c: 'Answer C',
+    d: 'Answer D',
+    level: null,
+    metadata: null,
+    created_at: null,
+    updated_at: null
+  }
+
+  const randomizedQuestion: RandomizedQuestion = {
+    id: baseQuestion.id,
+    question: baseQuestion.question,
+    category: baseQuestion.category,
+    difficulty: baseQuestion.difficulty,
+    answers: {
+      a: 'Answer A',
+      b: 'Answer B',
+      c: 'Answer C',
+      d: 'Answer D'
+    },
+    correct_answer: 'b',
+    original_correct: 'a',
+    randomization_seed: 'seed',
+    created_at: baseQuestion.created_at
+  }
+
+  const mockRandomize = vi.spyOn(QuestionService, 'randomizeAnswers')
+
+  beforeEach(() => {
+    mockRandomize.mockReturnValue(randomizedQuestion)
+
+    ;(supabase.rpc as unknown as Mock).mockReset()
+    ;(supabase.from as unknown as Mock).mockReset()
+  })
+
+  afterEach(() => {
+    mockRandomize.mockReset()
+  })
+
+  it('uses the RPC helper when available', async () => {
+    const rpcRecord = {
+      id: 'game-question-id',
+      game_id: 'game-id',
+      question_id: baseQuestion.id,
+      round_number: 1,
+      question_order: 2,
+      shuffled_answers: ['Answer A', 'Answer B', 'Answer C', 'Answer D'],
+      correct_position: 1
+    }
+
+    ;(supabase.rpc as unknown as Mock).mockResolvedValue({ data: rpcRecord, error: null })
+
+    const response = await QuestionService.addQuestionToGame('game-id', baseQuestion.id, 1, 2, baseQuestion)
+
+    expect(response.error).toBeNull()
+    expect(response.data?.question_order).toBe(2)
+    expect(supabase.rpc).toHaveBeenCalledWith('prepare_game_question', {
+      game_id: 'game-id',
+      question_id: baseQuestion.id,
+      round_number: 1,
+      question_number: 2,
+      shuffled_answers: ['Answer A', 'Answer B', 'Answer C', 'Answer D'],
+      correct_position: 1
+    })
+    expect(supabase.from).not.toHaveBeenCalled()
+  })
+
+  it('falls back to direct insert when RPC is unavailable', async () => {
+    ;(supabase.rpc as unknown as Mock).mockResolvedValue({
+      data: null,
+      error: { message: 'function prepare_game_question does not exist', code: 'PGRST102' }
+    })
+
+    const single = vi.fn().mockResolvedValue({
+      data: {
+        id: 'fallback-id',
+        game_id: 'game-id',
+        question_id: baseQuestion.id,
+        round_number: 1,
+        question_order: 2,
+        shuffled_answers: ['Answer A', 'Answer B', 'Answer C', 'Answer D'],
+        correct_position: 1
+      },
+      error: null
+    })
+    const select = vi.fn().mockReturnValue({ single })
+    const insert = vi.fn().mockReturnValue({ select })
+    ;(supabase.from as unknown as Mock).mockReturnValue({ insert })
+
+    const response = await QuestionService.addQuestionToGame('game-id', baseQuestion.id, 1, 2, baseQuestion)
+
+    expect(response.error).toBeNull()
+    expect(response.data?.id).toBe('fallback-id')
+    expect(insert).toHaveBeenCalledWith([
+      {
+        game_id: 'game-id',
+        question_id: baseQuestion.id,
+        round_number: 1,
+        shuffled_answers: ['Answer A', 'Answer B', 'Answer C', 'Answer D'],
+        correct_position: 1,
+        question_order: 2
+      }
+    ])
+  })
+
+  it('returns an error when RPC fails with a real database issue', async () => {
+    ;(supabase.rpc as unknown as Mock).mockResolvedValue({
+      data: null,
+      error: { message: 'Not authorized', code: '42501' }
+    })
+
+    const response = await QuestionService.addQuestionToGame('game-id', baseQuestion.id, 1, 2, baseQuestion)
+
+    expect(response.data).toBeNull()
+    expect(response.error?.message).toBe('Not authorized')
+    expect(supabase.from).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add an RPC-backed path in `QuestionService.addQuestionToGame` so that the client uses a server helper to prepare questions when available, while keeping the legacy insert fallback
- introduce utilities that call the RPC and detect when it is unavailable to avoid surfacing the generic failure seen when starting a game
- create a migration defining the `prepare_game_question` function that clears conflicting rows and inserts the requested question safely, and add focused unit tests that exercise the RPC path and the fallback logic

## Testing
- npm test -- src/services/__tests__/questionService.addQuestionToGame.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d3fc1aa8188323afe9bdf1e224ede1