### PR TITLE
Fix seeded shuffle to avoid TypeError during game start

### DIFF
--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -836,21 +836,28 @@ export class QuestionService {
 
   // Utility: Shuffle array with seed for deterministic randomization
   private static shuffleWithSeed<T>(array: T[], seed: number): T[] {
-    const shuffled = [...array]
-    let currentIndex = shuffled.length
-    let randomIndex: number
-
-    // Use seed-based random number generator
-    const seededRandom = () => {
-      seed = (seed * 9301 + 49297) % 233280
-      return seed / 233280
+    if (!Array.isArray(array)) {
+      console.error('[QuestionService.shuffleWithSeed] Expected array input', {
+        receivedType: typeof array,
+        receivedValue: array
+      })
+      return []
     }
 
-    while (currentIndex !== 0) {
-      randomIndex = Math.floor(seededRandom() * currentIndex)
-      currentIndex--
+    const shuffled = [...array]
+    const normalizedSeed = Number.isFinite(seed) ? Math.abs(Math.floor(seed)) : 0
+    let workingSeed = normalizedSeed % 233280
 
-      [shuffled[currentIndex], shuffled[randomIndex]] = [shuffled[randomIndex], shuffled[currentIndex]]
+    const seededRandom = () => {
+      workingSeed = (workingSeed * 9301 + 49297) % 233280
+      return workingSeed / 233280
+    }
+
+    for (let currentIndex = shuffled.length - 1; currentIndex > 0; currentIndex--) {
+      const randomIndex = Math.floor(seededRandom() * (currentIndex + 1))
+      const temp = shuffled[currentIndex]
+      shuffled[currentIndex] = shuffled[randomIndex] as T
+      shuffled[randomIndex] = temp as T
     }
 
     return shuffled


### PR DESCRIPTION
## Summary
- guard the deterministic shuffle against non-array inputs and normalize the seed
- replace the destructuring swap with an explicit swap that avoids assigning onto primitives
- keep seeded shuffling deterministic while preventing the `Cannot create property '[object Object]' on number '4'` error seen during question preparation

## Testing
- npm test *(fails: requires Supabase/realtime services; existing suite has numerous contract/realtime failures)*
- npm run lint *(fails: pre-existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d42278f640832382a4f1ed336fb779